### PR TITLE
fix: 공고 신청, 취소 버그 수정

### DIFF
--- a/src/lib/services/servicesClient.ts
+++ b/src/lib/services/servicesClient.ts
@@ -31,7 +31,6 @@ services.interceptors.request.use(config => {
   const { accessToken } = useAuthStore.getState();
 
   if (accessToken) {
-    console.log(accessToken);
     config.headers.Authorization = `Bearer ${accessToken}`;
   }
 


### PR DESCRIPTION
## 개요

Resolves: #68

### 문제
공고를 **취소한 뒤 다시 신청**했을 때 다음과 같은 문제가 발생
- 재신청 후 공고 상세 조회
    - `currentUserApplication.status` 취소상태 유지
    - **`currentUserApplication.id`**는 이전 지원 정보 id 그대로 유지됨
- 이 상태에서 해당 id로 다시 공고 취소 요청을 보내면 서버에서 **“이미 처리된 지원 정보입니다”** 라는 에러 응답을 받음

### 이유 
- 유저는 “내 공고 지원 목록”을 조회할 수 있음
- 동일한 공고에 대해 **여러 개의 지원 정보가 존재**
- 공고 상세의 `currentUserApplication.id`와 "내 지원 목록"의 같은 공고에 대한 지원 정보 id가 **서로 다름**

### 해결방법 
1. 유저의 공고 지원 목록 조회
2. 해당 공고 id와 일치하는 지원 정보 필터링
3. 가장 최신(createdAt 기준) 지원 정보 선택
4. 해당 id를 사용해 공고 취소 요청


## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
